### PR TITLE
Add workbench path override setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,12 @@
 					"type": "boolean",
 					"default": true,
 					"description": "This option will control: Cut, Copy, Paste."
+				},
+				"custom-contextmenu.workbenchPath": {
+					"title": "Workbench Path Override",
+					"type": "string",
+					"default": "",
+					"description": "Optional path to VS Code's workbench.html/workbench.esm.html file or the workbench directory to use when the default installation path cannot be detected."
 				}
 			}
 		}


### PR DESCRIPTION
### Motivation

- The extension could not reliably locate VS Code's `workbench.html`/`workbench.esm.html` on some installations, causing failure to install the custom context menu.  
- Provide a user-configurable override so users can point the extension directly to the workbench file or directory.  
- Ensure backups and patches operate against the resolved workbench location instead of assuming the default install path.

### Description

- Added a new configuration `custom-contextmenu.workbenchPath` to `package.json` to allow users to override the workbench path.  
- Read the new setting in `src/extension.js` and introduced `resolveWorkbenchHtmlFile(appRoot, workbenchPath)` to locate the HTML file from an explicit path, a directory, or the default installation layout.  
- Compute `htmlFile` via the resolver and early-return with `msg.unableToLocateVsCodeInstallationPath` if not found, and derive `workbenchDir` for backup file placement using the resolved path.  
- Updated `BackupFilePath` and related logic to use the resolved workbench directory and preserved existing patch/backups behavior otherwise.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea13aabf883288a64429aab467eca)