### PR TITLE
Make CSP meta tag removal more robust before injecting inline script

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -145,7 +145,7 @@ function activate(context) {
 		html = clearExistingPatches(html);
 
 		const injectHTML = await patchScript();
-		html = html.replace(/<meta\s+http-equiv="Content-Security-Policy"[\s\S]*?\/>/, "");
+		html = removeCspMetaTag(html);
 
 		html = html.replace(
 			/(<\/html>)/,
@@ -169,6 +169,13 @@ function activate(context) {
 		);
 		html = html.replace(/<!-- !! VSCODE-CUSTOM-CSS-SESSION-ID [\w-]+ !! -->\n*/g, "");
 		return html;
+	}
+
+	function removeCspMetaTag(html) {
+		return html.replace(
+			/<meta\b[^>]*http-equiv=(?:"|')Content-Security-Policy(?:"|')[^>]*>/gi,
+			""
+		);
 	}
 
 	async function patchScript() {


### PR DESCRIPTION
### Motivation
- Inline script injection into the VS Code workbench HTML can be blocked by an existing Content Security Policy meta tag, causing CSP errors when the extension tries to inject `user.js`.
- The previous ad-hoc replace was brittle and didn't reliably remove all variants of the CSP meta tag, so a more robust removal is required.

### Description
- Add a new helper `removeCspMetaTag(html)` that strips any `<meta ... http-equiv="Content-Security-Policy" ...>` occurrence using a tolerant regex.
- Replace the previous single-call replace in `performPatch` with a call to `removeCspMetaTag` before injecting the inline `<script>` in `src/extension.js`.
- No changes to backup/restore logic or the injection format besides the CSP meta stripping.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea6394b00832893ab14da4082080a)