### PR TITLE
Default selectors to empty, document selectors usage, remove packaged files and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,17 @@ Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu
 
 - Plain quoted strings match exact labels (e.g., `"\"Copy\""`).
 - Prefix with `^` to match items that start with a label (e.g., `"^\"Go to\""`).
-- Use `"_":has( + ...)` to target separators around specific items.
+- Separators are represented by the placeholder label `"_"`. Use `"_":has( + ...)` to hide the separator that appears before the matched item, and use the `... + "_"` pattern to hide the separator after the matched item.
+
+Separator examples:
+
+```json
+"custom-contextmenu.selectors": [
+  "\"_\":has( + \"Share\")",
+  "\"Share\" + \"_\""
+]
+```
+
+The first entry hides the separator immediately before the `Share` menu item (when present). The second entry hides the separator immediately after the `Share` menu item (when present).
+
+> Note: each entry must include quoted labels because the selector syntax is matched against aria-label values. You currently need to include the escaped quotes (e.g., `"\"Copy\""`). A future update could add a friendlier syntax, but for now keep the quotes.

--- a/README.md
+++ b/README.md
@@ -20,29 +20,27 @@ Make the contextmenu of VSCode cleaner!
 
 ### Selectors configuration
 
-Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their aria-label. Each entry is a selector pattern that the extension converts into an attribute selector before filtering the menu items. You can now omit the quotes around labels; the extension will add them for you.
+Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their aria-label. Each entry is a selector pattern that the extension converts into an attribute selector before filtering the menu items. The extension will wrap plain labels in quotes for you.
 
 ```json
 "custom-contextmenu.selectors": [
-  "^Go to",
   "Cut",
   "Copy",
-  "Paste",
-  "_:has( + ^Find All)"
+  "Paste"
 ]
 ```
 
 - Plain labels match exact labels (e.g., `"Copy"`).
-- Prefix with `^` to match items that start with a label (e.g., `"^Go to"`).
-- Separators are represented by the placeholder label `_`. Use `_:has( + ...)` to hide the separator that appears before the matched item, and use the `... + _` pattern to hide the separator after the matched item.
+- Prefix with `^` to match items that start with a label (e.g., `"^Go to"`). For this and other advanced patterns, include the quotes yourself.
+- Separators are represented by the placeholder label `"_"`. Use `"_":has( + ...)` to hide the separator that appears before the matched item, and use the `... + "_"` pattern to hide the separator after the matched item.
 
 Separator examples:
 
 ```json
 "custom-contextmenu.selectors": [
-  "_:has( + Share)",
-  "Share + _"
+  "\"_\":has( + \"Share\")",
+  "\"Share\" + \"_\""
 ]
 ```
 
-The first entry hides the separator immediately before the `Share` menu item (when present). The second entry hides the separator immediately after the `Share` menu item (when present). If you prefer to use the full quoted syntax, it still works (e.g., `"\"Share\" + \"_\""`).
+The first entry hides the separator immediately before the `Share` menu item (when present). The second entry hides the separator immediately after the `Share` menu item (when present).

--- a/README.md
+++ b/README.md
@@ -20,27 +20,29 @@ Make the contextmenu of VSCode cleaner!
 
 ### Selectors configuration
 
-Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their aria-label. Each entry is a selector pattern that the extension converts into an attribute selector before filtering the menu items. The extension will wrap plain labels in quotes for you.
+Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their aria-label. Each entry is a selector pattern that the extension converts into an attribute selector before filtering the menu items. The extension will add quotes for you, including separator patterns and `^`-prefixed starts-with matches.
 
 ```json
 "custom-contextmenu.selectors": [
+  "^Go to",
   "Cut",
   "Copy",
-  "Paste"
+  "Paste",
+  "_:has( + ^Find All)"
 ]
 ```
 
 - Plain labels match exact labels (e.g., `"Copy"`).
-- Prefix with `^` to match items that start with a label (e.g., `"^Go to"`). For this and other advanced patterns, include the quotes yourself.
-- Separators are represented by the placeholder label `"_"`. Use `"_":has( + ...)` to hide the separator that appears before the matched item, and use the `... + "_"` pattern to hide the separator after the matched item.
+- Prefix with `^` to match items that start with a label (e.g., `"^Go to"`).
+- Separators are represented by the placeholder label `"_"`. Use `_:has( + ...)` to hide the separator that appears before the matched item, and use the `... + _` pattern to hide the separator after the matched item.
 
 Separator examples:
 
 ```json
 "custom-contextmenu.selectors": [
-  "\"_\":has( + \"Share\")",
-  "\"Share\" + \"_\""
+  "_:has( + Share)",
+  "Share + _"
 ]
 ```
 
-The first entry hides the separator immediately before the `Share` menu item (when present). The second entry hides the separator immediately after the `Share` menu item (when present).
+The first entry hides the separator immediately before the `Share` menu item (when present). The second entry hides the separator immediately after the `Share` menu item (when present). If you prefer the fully-quoted syntax, it still works (e.g., `"\"Share\" + \"_\""`).

--- a/README.md
+++ b/README.md
@@ -20,31 +20,29 @@ Make the contextmenu of VSCode cleaner!
 
 ### Selectors configuration
 
-Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their aria-label. Each entry is a selector pattern that the extension converts into an attribute selector before filtering the menu items. Examples:
+Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their aria-label. Each entry is a selector pattern that the extension converts into an attribute selector before filtering the menu items. You can now omit the quotes around labels; the extension will add them for you.
 
 ```json
 "custom-contextmenu.selectors": [
-  "^\"Go to\"",
-  "\"Cut\"",
-  "\"Copy\"",
-  "\"Paste\"",
-  "\"_\":has( + ^\"Find All\")"
+  "^Go to",
+  "Cut",
+  "Copy",
+  "Paste",
+  "_:has( + ^Find All)"
 ]
 ```
 
-- Plain quoted strings match exact labels (e.g., `"\"Copy\""`).
-- Prefix with `^` to match items that start with a label (e.g., `"^\"Go to\""`).
-- Separators are represented by the placeholder label `"_"`. Use `"_":has( + ...)` to hide the separator that appears before the matched item, and use the `... + "_"` pattern to hide the separator after the matched item.
+- Plain labels match exact labels (e.g., `"Copy"`).
+- Prefix with `^` to match items that start with a label (e.g., `"^Go to"`).
+- Separators are represented by the placeholder label `_`. Use `_:has( + ...)` to hide the separator that appears before the matched item, and use the `... + _` pattern to hide the separator after the matched item.
 
 Separator examples:
 
 ```json
 "custom-contextmenu.selectors": [
-  "\"_\":has( + \"Share\")",
-  "\"Share\" + \"_\""
+  "_:has( + Share)",
+  "Share + _"
 ]
 ```
 
-The first entry hides the separator immediately before the `Share` menu item (when present). The second entry hides the separator immediately after the `Share` menu item (when present).
-
-> Note: each entry must include quoted labels because the selector syntax is matched against aria-label values. You currently need to include the escaped quotes (e.g., `"\"Copy\""`). A future update could add a friendlier syntax, but for now keep the quotes.
+The first entry hides the separator immediately before the `Share` menu item (when present). The second entry hides the separator immediately after the `Share` menu item (when present). If you prefer to use the full quoted syntax, it still works (e.g., `"\"Share\" + \"_\""`).

--- a/README.md
+++ b/README.md
@@ -17,3 +17,21 @@ Make the contextmenu of VSCode cleaner!
 1. install this extension in VSCode
 2. open Command Pallete with `F1` or `ctrl+shift+p`
 3. select `Enable Custom Contextmenu`
+
+### Selectors configuration
+
+Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their aria-label. Each entry is a selector pattern that the extension converts into an attribute selector before filtering the menu items. Examples:
+
+```json
+"custom-contextmenu.selectors": [
+  "^\"Go to\"",
+  "\"Cut\"",
+  "\"Copy\"",
+  "\"Paste\"",
+  "\"_\":has( + ^\"Find All\")"
+]
+```
+
+- Plain quoted strings match exact labels (e.g., `"\"Copy\""`).
+- Prefix with `^` to match items that start with a label (e.g., `"^\"Go to\""`).
+- Use `"_":has( + ...)` to target separators around specific items.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,7 @@ Separator examples:
 ```
 
 The first entry hides the separator immediately before the `Share` menu item (when present). The second entry hides the separator immediately after the `Share` menu item (when present). If you prefer the fully-quoted syntax, it still works (e.g., `"\"Share\" + \"_\""`).
+
+> Note: `Paste + _` (or `Share + _`) only hides the separator after the item. To hide the menu item itself, add the item label separately (for example, include `"Paste"`).
+
+> Note: after changing `custom-contextmenu.selectors`, re-enable the custom context menu or restart VS Code so the injected script is updated.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
 				"custom-contextmenu.selectors": {
 					"title": "Context Menu Selectors",
 					"type": "array",
+					"items": {
+						"type": "string"
+					},
 					"default": [],
 					"description": "List of aria-label selectors to hide from the context menu."
 				},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-custom-contextmenu",
 	"displayName": "Custom Contextmenu",
 	"description": "Custom Cleaner Contextmenu for Visual Studio Code",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"publisher": "BHznJNs",
 	"engines": {
 		"vscode": "^1.92.0"
@@ -19,9 +19,6 @@
 	"icon": "images/logo.png",
 	"activationEvents": ["*"],
 	"main": "./src/extension",
-	"files": [
-		"src/static/*"
-	],
 	"contributes": {
 		"commands": [
 			{
@@ -36,17 +33,11 @@
 		"configuration": {
 			"type": "object",
 			"properties": {
-				"custom-contextmenu.showGoTos": {
-					"title": "Show Go-Tos",
-					"type": "boolean",
-					"default": true,
-					"description": "This option will control: Go to Definition, Go to Type Definition, Go to Implementations, Go to References, Go to Source Definition."
-				},
-				"custom-contextmenu.showClipboardItems": {
-					"title": "Show Clipboard Items",
-					"type": "boolean",
-					"default": true,
-					"description": "This option will control: Cut, Copy, Paste."
+				"custom-contextmenu.selectors": {
+					"title": "Context Menu Selectors",
+					"type": "array",
+					"default": [],
+					"description": "List of aria-label selectors to hide from the context menu."
 				},
 				"custom-contextmenu.workbenchPath": {
 					"title": "Workbench Path Override",

--- a/src/extension.js
+++ b/src/extension.js
@@ -207,6 +207,25 @@ function activate(context) {
 		if (trimmed.includes('"')) {
 			return trimmed;
 		}
+		if (trimmed === "_") {
+			return '"_"';
+		}
+		const separatorBeforeMatch = trimmed.match(/^_:\s*has\(\s*\+\s*(.+?)\s*\)$/);
+		if (separatorBeforeMatch) {
+			return `"_":has( + ${quoteLabel(separatorBeforeMatch[1])})`;
+		}
+		const separatorAfterMatch = trimmed.match(/^(.+?)\s*\+\s*_$/);
+		if (separatorAfterMatch) {
+			return `${quoteLabel(separatorAfterMatch[1])} + "_"`;
+		}
+		return quoteLabel(trimmed);
+	}
+
+	function quoteLabel(label) {
+		const trimmed = label.trim();
+		if (trimmed.startsWith("^")) {
+			return `^"${trimmed.slice(1)}"`;
+		}
 		return `"${trimmed}"`;
 	}
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -261,9 +261,27 @@ function activate(context) {
 		"custom-contextmenu.uninstallCustomContextmenu",
 		cmdUninstall
 	);
+	const configChangeHandler = vscode.workspace.onDidChangeConfiguration((event) => {
+		if (!event.affectsConfiguration("custom-contextmenu.selectors")) {
+			return;
+		}
+		vscode.window
+			.showInformationMessage(
+				"Custom context menu selectors updated. Re-enable the custom context menu to apply changes.",
+				"Re-enable"
+			)
+			.then((btn) => {
+				if (btn === "Re-enable") {
+					vscode.commands.executeCommand(
+						"custom-contextmenu.installCustomContextmenu"
+					);
+				}
+			});
+	});
 
 	context.subscriptions.push(installCustomCSS);
 	context.subscriptions.push(uninstallCustomCSS);
+	context.subscriptions.push(configChangeHandler);
 
 	console.log("vscode-custom-css is active!");
 	console.log("Application directory", appDir);

--- a/src/extension.js
+++ b/src/extension.js
@@ -207,25 +207,6 @@ function activate(context) {
 		if (trimmed.includes('"')) {
 			return trimmed;
 		}
-		if (trimmed === "_") {
-			return '"_"';
-		}
-		const separatorBeforeMatch = trimmed.match(/^_:\s*has\(\s*\+\s*(.+?)\s*\)$/);
-		if (separatorBeforeMatch) {
-			return `"_":has( + ${quoteLabel(separatorBeforeMatch[1])})`;
-		}
-		const separatorAfterMatch = trimmed.match(/^(.+?)\s*\+\s*_$/);
-		if (separatorAfterMatch) {
-			return `${quoteLabel(separatorAfterMatch[1])} + "_"`;
-		}
-		return quoteLabel(trimmed);
-	}
-
-	function quoteLabel(label) {
-		const trimmed = label.trim();
-		if (trimmed.startsWith("^")) {
-			return `^"${trimmed.slice(1)}"`;
-		}
 		return `"${trimmed}"`;
 	}
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -187,10 +187,12 @@ function activate(context) {
 			vscode.window.showErrorMessage(`Error reading file: ${error.message}`);
 		}
 		const config = vscode.workspace.getConfiguration('custom-contextmenu');
-		const showGoTos = config.get('showGoTos');
-		const showClipboardItems = config.get('showClipboardItems');
-		fileContent = fileContent.replace('%showGoTos%', showGoTos);
-		fileContent = fileContent.replace('%showClipboardItems%', showClipboardItems);
+		const selectors = config.get('selectors');
+		const normalizedSelectors = Array.isArray(selectors) ? selectors : [];
+		fileContent = fileContent.replace(
+			'%selectors%',
+			JSON.stringify(normalizedSelectors)
+		);
 		return `<script>${fileContent}</script>`;
 	}
 

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -6,46 +6,7 @@
 
 (function() {
   console.log("Hello from custom_context_menu.js~");
-  const showGoTos = %showGoTos%;
-  const showClipboardItems = %showClipboardItems%;
-
-  const selectors = [
-    /// original selectors
-    /// '^"Go to"', // start with "Go to"
-    /// '"Change All Occurrences"', // exact match
-    /// '"Share"',
-    /// '"Share" + "_"', // separator after "Share"
-    /// '"_":has( + "Share")', // separator before "Share"
-    /// '"Command Palette..."',
-    /// '"_":has( + "Command Palette...")',
-    /// '"Layout Controls"',
-
-    '"Change All Occurrences"', // exact match
-
-    '^"Find All"', '^"查找所有"',
-    '^"Find All" + "_"', '^"查找所有" + "_"', // separator after "Share"
-    '"_":has( + ^"Find All")', '"_":has( + ^"查找所有")', // separator before "Share"
-
-    '"Share"', '"共享"',
-    '"Share" + "_"', '"共享" + "_"', // separator after "Share"
-    '"_":has( + "Share")', '"_":has( + "共享")', // separator before "Share"
-
-    '"Command Palette..."', '"命令面板..."',
-    '"_":has( + "Command Palette...")', '"_":has( + "命令面板...")',
-
-    '"Layout Controls"',
-    '^"Git"', '"_":has( + ^"Git")',
-  ];
-  if (showGoTos) {
-    // start with "Go to"
-    selectors.push('^"Go to"', '^"转到"')
-  }
-  if (showClipboardItems) {
-    selectors.push(
-      '"Cut"', '"Copy"', '"Paste"',
-      '"剪切"', '"复制"', '"粘贴"',
-    )
-  }
+  const selectors = %selectors%;
 
   const css_selectors = selectors
     .join(",\n")


### PR DESCRIPTION
### Motivation

- Replace legacy boolean flags with a single, extensible `selectors` configuration so users can control which context-menu items are hidden via selector patterns.
- Leave the default selectors blank so users intentionally opt into hiding items by configuring `custom-contextmenu.selectors`.
- Remove the packaged `files` entry to avoid shipping `src/static/*` explicitly and simplify packaging.
- Provide documentation and examples for how to write selector patterns so the setting is easy to use.

### Description

- Update `package.json` to bump the extension `version` to `0.1.6`, remove the `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ea7ec99988328b6ec688c47f97431)