### PR TITLE
Auto-hide trailing context menu separators

### DIFF
--- a/src/static/user.js
+++ b/src/static/user.js
@@ -139,15 +139,25 @@
 
   function hideTrailingSeparator(container) {
     const items = Array.from(container.querySelectorAll(".action-item"));
+    const isRendered = item => {
+      const style = getComputedStyle(item);
+      return (
+        style.display !== "none" &&
+        style.visibility !== "hidden" &&
+        item.getClientRects().length > 0
+      );
+    };
     const isSeparator = item =>
-      item.classList.contains("separator") || item.getAttribute("role") === "separator";
+      item.classList.contains("separator") ||
+      item.getAttribute("role") === "separator" ||
+      item.querySelector(".codicon.separator");
     for (const item of items) {
       if (item.dataset.autoHideSeparator === "true") {
         item.style.removeProperty("display");
         delete item.dataset.autoHideSeparator;
       }
     }
-    const visibleItems = items.filter(item => getComputedStyle(item).display !== "none");
+    const visibleItems = items.filter(isRendered);
     const lastItem = visibleItems.at(-1);
     if (lastItem && isSeparator(lastItem)) {
       lastItem.dataset.autoHideSeparator = "true";

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -158,6 +158,11 @@
       }
     }
     const visibleItems = items.filter(isRendered);
+    const firstItem = visibleItems.at(0);
+    if (firstItem && isSeparator(firstItem)) {
+      firstItem.dataset.autoHideSeparator = "true";
+      firstItem.style.display = "none";
+    }
     const lastItem = visibleItems.at(-1);
     if (lastItem && isSeparator(lastItem)) {
       lastItem.dataset.autoHideSeparator = "true";

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -106,6 +106,9 @@
         }
       }
       `.replaceAll(/\s+/g, " ");
+    requestAnimationFrame(() => {
+      hideTrailingSeparator(container);
+    });
 
     // fix context menu position
     if (menu.matches(".monaco-submenu")) {
@@ -131,6 +134,24 @@
         }
       }
       menu.style.top = menu_top + "px";
+    }
+  }
+
+  function hideTrailingSeparator(container) {
+    const items = Array.from(container.querySelectorAll(".action-item"));
+    const isSeparator = item =>
+      item.classList.contains("separator") || item.getAttribute("role") === "separator";
+    for (const item of items) {
+      if (item.dataset.autoHideSeparator === "true") {
+        item.style.removeProperty("display");
+        delete item.dataset.autoHideSeparator;
+      }
+    }
+    const visibleItems = items.filter(item => getComputedStyle(item).display !== "none");
+    const lastItem = visibleItems.at(-1);
+    if (lastItem && isSeparator(lastItem)) {
+      lastItem.dataset.autoHideSeparator = "true";
+      lastItem.style.display = "none";
     }
   }
 })();


### PR DESCRIPTION
### Motivation
- Prevent trailing separator entries from remaining as the last visible item after menu items are filtered.
- Improve context menu appearance by removing orphaned separators introduced by selector-based filtering.
- Ensure separators are restored properly when menu contents change so behavior stays predictable.

### Description
- Added `hideTrailingSeparator` in `src/static/user.js` to detect separator items and hide a trailing separator using an `data-auto-hide-separator` marker so it can be restored later.
- Invoke `requestAnimationFrame(() => hideTrailingSeparator(container))` from `modify` to run the logic after the menu is rendered.
- Separator detection checks the `.separator` class or `role="separator"` and toggles inline `display` to hide/show the element.
- Previously auto-hidden separators are restored at the start of each run before recalculation to avoid persistent hiding.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb8117038832883b1848e905015af)