### PR TITLE
Bump version to 0.2.0 and update publisher to EpicStuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,18 +2,18 @@
 	"name": "vscode-custom-contextmenu",
 	"displayName": "Custom Contextmenu",
 	"description": "Custom Cleaner Contextmenu for Visual Studio Code",
-	"version": "0.1.6",
-	"publisher": "BHznJNs",
+	"version": "0.2.0",
+	"publisher": "EpicStuff",
 	"engines": {
 		"vscode": "^1.92.0"
 	},
 	"categories": ["Other"],
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/BHznJNs/vscode-custom-contextmenu"
+		"url": "https://github.com/EpicStuff/vscode-custom-contextmenu"
 	},
 	"bugs": {
-		"url": "https://github.com/BHznJNs/vscode-custom-contextmenu/issues"
+		"url": "https://github.com/EpicStuff/vscode-custom-contextmenu/issues"
 	},
 	"preview": true,
 	"icon": "images/logo.png",


### PR DESCRIPTION
### Motivation
- Bump the minor version to mark a new release of the extension.
- Replace legacy publisher and repository references from `BHznJNs` to `EpicStuff` to reflect updated ownership/branding.
- Ensure package metadata points to the correct GitHub repository and issues URL.

### Description
- Update `version` in `package.json` from `0.1.6` to `0.2.0`.
- Replace the `publisher` value with `EpicStuff` in `package.json`.
- Update `repository.url` and `bugs.url` in `package.json` to `https://github.com/EpicStuff/vscode-custom-contextmenu`.
- All changes were applied to `package.json` and committed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ebe7a8b808328ac3c12eca2bcc9fd)