### PR TITLE
Add grouped context menu headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,25 @@ The first entry hides the separator immediately before the `Share` menu item (wh
 
 > Note: after changing `custom-contextmenu.selectors`, re-enable the custom context menu or restart VS Code so the injected script is updated.
 
+### Grouping configuration
+
+Define `custom-contextmenu.groups` to insert labeled headers and regroup related items. Each group has a label and the same selector patterns used for hiding items. Groups are applied in order; matched items are moved under the group's label.
+
+```json
+"custom-contextmenu.groups": [
+  {
+    "label": "Navigation",
+    "selectors": ["^Go to", "Find All References"]
+  },
+  {
+    "label": "Clipboard",
+    "selectors": ["Cut", "Copy", "Paste"]
+  }
+]
+```
+
+> Note: after changing `custom-contextmenu.groups`, re-enable the custom context menu or restart VS Code so the injected script is updated.
+
 ## Note:
 
 All changes were made by ChatGPT (and I've got no idea how to make vscode extensions or do javascript, but this does seem to be working).

--- a/package.json
+++ b/package.json
@@ -47,6 +47,29 @@
 					"type": "string",
 					"default": "",
 					"description": "Optional path to VS Code's workbench.html/workbench.esm.html file or the workbench directory to use when the default installation path cannot be detected."
+				},
+				"custom-contextmenu.groups": {
+					"title": "Context Menu Groups",
+					"type": "array",
+					"default": [],
+					"description": "Optional grouping rules to insert headers and regroup context menu items.",
+					"items": {
+						"type": "object",
+						"required": ["label", "selectors"],
+						"properties": {
+							"label": {
+								"type": "string",
+								"description": "Group label shown in the context menu."
+							},
+							"selectors": {
+								"type": "array",
+								"description": "Selectors used to match items that should be placed under this group.",
+								"items": {
+									"type": "string"
+								}
+							}
+						}
+					}
 				}
 			}
 		}

--- a/src/extension.js
+++ b/src/extension.js
@@ -192,9 +192,18 @@ function activate(context) {
 		const formattedSelectors = normalizedSelectors
 			.filter((selector) => typeof selector === 'string')
 			.map((selector) => formatSelector(selector));
+		const groups = config.get('groups');
+		const normalizedGroups = Array.isArray(groups) ? groups : [];
+		const formattedGroups = normalizedGroups
+			.map((group) => formatGroup(group))
+			.filter((group) => group);
 		fileContent = fileContent.replace(
 			'%selectors%',
 			JSON.stringify(formattedSelectors)
+		);
+		fileContent = fileContent.replace(
+			'%groups%',
+			JSON.stringify(formattedGroups)
 		);
 		return `<script>${fileContent}</script>`;
 	}
@@ -227,6 +236,24 @@ function activate(context) {
 			return `^"${trimmed.slice(1)}"`;
 		}
 		return `"${trimmed}"`;
+	}
+
+	function formatGroup(group) {
+		if (!group || typeof group !== 'object') {
+			return null;
+		}
+		const label = typeof group.label === 'string' ? group.label.trim() : '';
+		if (!label) {
+			return null;
+		}
+		const selectors = Array.isArray(group.selectors) ? group.selectors : [];
+		const formattedSelectors = selectors
+			.filter((selector) => typeof selector === 'string')
+			.map((selector) => formatSelector(selector));
+		return {
+			label,
+			selectors: formattedSelectors,
+		};
 	}
 
 	function reloadWindow() {
@@ -262,12 +289,15 @@ function activate(context) {
 		cmdUninstall
 	);
 	const configChangeHandler = vscode.workspace.onDidChangeConfiguration((event) => {
-		if (!event.affectsConfiguration("custom-contextmenu.selectors")) {
+		if (
+			!event.affectsConfiguration("custom-contextmenu.selectors") &&
+			!event.affectsConfiguration("custom-contextmenu.groups")
+		) {
 			return;
 		}
 		vscode.window
 			.showInformationMessage(
-				"Custom context menu selectors updated. Re-enable the custom context menu to apply changes.",
+				"Custom context menu settings updated. Re-enable the custom context menu to apply changes.",
 				"Re-enable"
 			)
 			.then((btn) => {

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -228,11 +228,20 @@
     const header = document.createElement("li");
     header.className = "action-item custom-contextmenu-group";
     header.setAttribute("role", "presentation");
-    const text = document.createElement("span");
-    text.className = "action-label";
-    text.setAttribute("aria-label", label);
-    text.textContent = label;
-    header.appendChild(text);
+    header.setAttribute("tabindex", "-1");
+
+    const link = document.createElement("a");
+    link.className = "action-menu-item";
+    link.setAttribute("role", "menuitem");
+    link.setAttribute("tabindex", "0");
+
+    const labelSpan = document.createElement("span");
+    labelSpan.className = "action-label";
+    labelSpan.setAttribute("aria-label", label);
+    labelSpan.textContent = label;
+
+    link.appendChild(labelSpan);
+    header.appendChild(link);
     return header;
   }
 })();

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -7,10 +7,26 @@
 (function() {
   console.log("Hello from custom_context_menu.js~");
   const selectors = %selectors%;
+  const groups = %groups%;
 
-  const css_selectors = selectors
-    .join(",\n")
-    .replaceAll(/([*^|])?"(.+?)"/g, '[aria-label\x241="\x242"]');
+  const css_selectors = buildCssSelectors(selectors);
+
+  function buildCssSelectors(list) {
+    return list
+      .join(",\n")
+      .replaceAll(/([*^|])?"(.+?)"/g, '[aria-label\x241="\x242"]');
+  }
+
+  function buildCssSelectorList(list) {
+    if (!Array.isArray(list)) {
+      return [];
+    }
+    const css = buildCssSelectors(list);
+    if (!css.trim()) {
+      return [];
+    }
+    return css.split(",").map((entry) => entry.trim()).filter(Boolean);
+  }
 
   function wait_for(root) {
     const selector = ".monaco-menu-container > .monaco-scrollable-element";
@@ -66,7 +82,15 @@
           display: none !important;
         }
       }
+      .custom-contextmenu-group .action-label {
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        opacity: 0.6;
+        pointer-events: none;
+      }
       `.replaceAll(/\s+/g, " ");
+    applyGrouping(container);
     requestAnimationFrame(() => {
       hideTrailingSeparator(container);
     });
@@ -129,5 +153,70 @@
       lastItem.dataset.autoHideSeparator = "true";
       lastItem.style.display = "none";
     }
+  }
+
+  function applyGrouping(container) {
+    if (!Array.isArray(groups) || groups.length === 0) {
+      return;
+    }
+    const actionsContainer =
+      container.querySelector(".actions") ||
+      container.querySelector(".monaco-action-bar") ||
+      container;
+    actionsContainer
+      .querySelectorAll(".custom-contextmenu-group")
+      .forEach((item) => item.remove());
+    const items = Array.from(
+      actionsContainer.querySelectorAll(".action-item")
+    ).filter((item) => !item.classList.contains("custom-contextmenu-group"));
+    const isSeparator = item =>
+      item.classList.contains("separator") ||
+      item.getAttribute("role") === "separator" ||
+      item.querySelector(".codicon.separator");
+    const used = new Set();
+    for (const group of groups) {
+      if (!group || typeof group.label !== "string") {
+        continue;
+      }
+      const selectorList = buildCssSelectorList(group.selectors || []);
+      if (selectorList.length === 0) {
+        continue;
+      }
+      const matchesSelectors = (item) =>
+        selectorList.some((selector) => item.matches(selector));
+      const groupItems = items.filter(
+        (item) =>
+          !used.has(item) &&
+          !isSeparator(item) &&
+          matchesSelectors(item)
+      );
+      if (groupItems.length === 0) {
+        continue;
+      }
+      const header = createGroupHeader(group.label);
+      actionsContainer.insertBefore(header, groupItems[0]);
+      let insertPoint = header;
+      for (const item of groupItems) {
+        if (item === insertPoint.nextSibling) {
+          insertPoint = item;
+        } else {
+          actionsContainer.insertBefore(item, insertPoint.nextSibling);
+          insertPoint = item;
+        }
+        used.add(item);
+      }
+    }
+  }
+
+  function createGroupHeader(label) {
+    const header = document.createElement("li");
+    header.className = "action-item custom-contextmenu-group";
+    header.setAttribute("role", "presentation");
+    const text = document.createElement("span");
+    text.className = "action-label";
+    text.setAttribute("aria-label", label);
+    text.textContent = label;
+    header.appendChild(text);
+    return header;
   }
 })();

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -68,8 +68,15 @@
     }
     for (let item of container.querySelectorAll(".action-item")) {
       const label = item.querySelector(".action-label");
-      const aria_label = label?.getAttribute("aria-label") || "_";
+      const rawLabel =
+        label?.getAttribute("aria-label") ||
+        label?.textContent ||
+        "_";
+      const aria_label = rawLabel.replace(/\s+/g, " ").trim() || "_";
       item.setAttribute("aria-label", aria_label);
+      if (label && aria_label) {
+        label.setAttribute("aria-label", aria_label);
+      }
     }
 
     const menu = container.parentNode;

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -160,6 +160,7 @@
       return;
     }
     const actionsContainer =
+      container.querySelector(".actions-container") ||
       container.querySelector(".actions") ||
       container.querySelector(".monaco-action-bar") ||
       container;
@@ -193,14 +194,29 @@
       if (groupItems.length === 0) {
         continue;
       }
+      const parentNode = groupItems[0].parentNode;
+      if (!parentNode) {
+        continue;
+      }
       const header = createGroupHeader(group.label);
-      actionsContainer.insertBefore(header, groupItems[0]);
+      if (parentNode.contains(groupItems[0])) {
+        parentNode.insertBefore(header, groupItems[0]);
+      } else {
+        parentNode.appendChild(header);
+      }
       let insertPoint = header;
       for (const item of groupItems) {
+        const targetParent = item.parentNode || parentNode;
+        if (targetParent !== parentNode) {
+          continue;
+        }
         if (item === insertPoint.nextSibling) {
           insertPoint = item;
+        } else if (insertPoint.parentNode === parentNode) {
+          parentNode.insertBefore(item, insertPoint.nextSibling);
+          insertPoint = item;
         } else {
-          actionsContainer.insertBefore(item, insertPoint.nextSibling);
+          parentNode.appendChild(item);
           insertPoint = item;
         }
         used.add(item);


### PR DESCRIPTION
### Motivation

- Improve context menu organization by allowing related items to be grouped under labeled headers.
- Let users declare groups using the same selector syntax as the existing `custom-contextmenu.selectors` setting so grouping is configurable.
- Apply grouping at runtime inside the injected script so the patched workbench reorders and annotates menu items when shown.

### Description

- Added a new `custom-contextmenu.groups` configuration in `package.json` to declare groups with a `label` and `selectors` array.
- Read and format groups in `src/extension.js` (`formatGroup`) and inject the JSON into the patched script as `%groups%` alongside `%selectors%`.
- Implemented grouping and header rendering in `src/static/user.js` with `applyGrouping`, `createGroupHeader`, helper selector builders, and styling for `.custom-contextmenu-group`.
- Updated the configuration change handler to watch `custom-contextmenu.groups` and added documentation and examples to `README.md`.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec14132ec8328bc29eee6fece88ee)