### PR TITLE
Fix visibility check for trailing separators in context menu

### DIFF
--- a/src/static/user.js
+++ b/src/static/user.js
@@ -101,11 +101,16 @@
   function hideTrailingSeparator(container) {
     const items = Array.from(container.querySelectorAll(".action-item"));
     const isRendered = item => {
-      const style = getComputedStyle(item);
+      const label = item.querySelector(".action-label, .action-menu-item");
+      const target = label || item;
+      const itemStyle = getComputedStyle(item);
+      const targetStyle = getComputedStyle(target);
       return (
-        style.display !== "none" &&
-        style.visibility !== "hidden" &&
-        item.getClientRects().length > 0
+        itemStyle.display !== "none" &&
+        itemStyle.visibility !== "hidden" &&
+        targetStyle.display !== "none" &&
+        targetStyle.visibility !== "hidden" &&
+        target.getClientRects().length > 0
       );
     };
     const isSeparator = item =>


### PR DESCRIPTION
### Motivation
- Trailing separators remained visible when following menu items were hidden by CSS selectors, causing visual separators to persist incorrectly.
- The previous visibility check only inspected the `.action-item` container which could report rendered even if the action label was hidden.
- The intent is to determine visibility based on the actual action label or menu item content so leading/trailing separators are removed correctly.

### Description
- Update `hideTrailingSeparator`'s `isRendered` to prefer the `.action-label` or `.action-menu-item` element as the `target` when present.
- Check computed styles for both the container (`item`) and the `target`, and use `target.getClientRects().length > 0` to decide rendering.
- Keep existing logic that restores `data-auto-hide-separator` and hides separators at the start/end of the visible item run.
- Change implemented in `src/static/user.js` by refining the `isRendered` function.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec9345d8c8328b2604a55f96d6885)