### PR TITLE
Emphasize manual `workbenchPath` setting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <h1>Custom Contextmenu</h1>
 </div>
 
-Make the contextmenu of VSCode cleaner!
+Remove any items from VSCode's contextmenu (right click menu)!
 
 ## Screenshots
 
@@ -14,14 +14,14 @@ Make the contextmenu of VSCode cleaner!
 
 ## Usage
 
-1. install this extension in VSCode
-1.5. manually set `custom-contextmenu.workbenchPath` (the auto-detection likely does not work) by locating your VS Code installation (e.g., right-click the VS Code shortcut and choose "Open file location"), searching for `workbench.html`/`workbench.esm.html`, then right-clicking the file and choosing "Copy as path"; set that path and re-run `Enable Custom Contextmenu`
-2. open Command Pallete with `F1` or `ctrl+shift+p`
-3. select `Enable Custom Contextmenu`
+&emsp;1\. install this extension in VSCode  
+&emsp;1.5. manually set `custom-contextmenu.workbenchPath` (the auto-detection likely does not work) by locating your VS Code installation (e.g., right-click the VS Code shortcut and choose "Open file location"), searching for `workbench.html`/`workbench.esm.html`, then right-clicking the file and choosing "Copy as path"; set that path and re-run `Enable Custom Contextmenu`  
+&emsp;2. open Command Pallete with `F1` or `ctrl+shift+p`  
+&emsp;3. select `Enable Custom Contextmenu`  
 
 ### Selectors configuration
 
-Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their aria-label. Each entry is a selector pattern that the extension converts into an attribute selector before filtering the menu items. The extension will add quotes for you, including separator patterns and `^`-prefixed starts-with matches.
+Set `custom-contextmenu.selectors` in your VS Code settings to hide context menu items by their label. Example:
 
 ```json
 "custom-contextmenu.selectors": [
@@ -54,4 +54,4 @@ The first entry hides the separator immediately before the `Share` menu item (wh
 
 ## Note:
 
-All changes were made by ChatGPT (and I've got no idea how to make vscode extensions or do javascript, but this does seem to be working).
+All changes were made by ChatGPT (and I've got no idea how to make vscode extensions or do javascript, but this extension does seem to be working).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Make the contextmenu of VSCode cleaner!
 ## Usage
 
 1. install this extension in VSCode
+1.5. manually set `custom-contextmenu.workbenchPath` (the auto-detection likely does not work) by locating your VS Code installation (e.g., right-click the VS Code shortcut and choose "Open file location"), searching for `workbench.html`/`workbench.esm.html`, then right-clicking the file and choosing "Copy as path"; set that path and re-run `Enable Custom Contextmenu`
 2. open Command Pallete with `F1` or `ctrl+shift+p`
 3. select `Enable Custom Contextmenu`
 


### PR DESCRIPTION
### Motivation
- The extension's automatic detection of VS Code's workbench path is unreliable, so users need a clear manual fallback.  
- Make the manual `workbenchPath` instruction more discoverable by placing it before running the enable command.  
- Reduce user confusion and support requests caused by failed automatic detection.  

### Description
- Updated the Usage section in `README.md` to add and reword step `1.5` to start by instructing users to manually set `custom-contextmenu.workbenchPath`.  
- The new step explains how to locate `workbench.html`/`workbench.esm.html` (e.g., via "Open file location" on the VS Code shortcut) and to use "Copy as path" to obtain the path.  
- Clarified that after setting the path the user should re-run `Enable Custom Contextmenu` to apply the change.  

### Testing
- This is a documentation-only change, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ec784a9c48328a401b55053cb43ed)