### PR TITLE
Fix README image links for VS Code marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
     <br />
-    <img src="./images/logo.png" alt="InputShare Logo" width="160" height="160" />
+    <img src="https://raw.githubusercontent.com/EpicStuff/vscode-custom-context-menu/main/images/logo.png" alt="InputShare Logo" width="160" height="160" />
     <h1>Custom Context Menu</h1>
 </div>
 
@@ -10,7 +10,7 @@ Remove any items from VSCode's context menu (right click menu)
 
 | Before | After |
 | --- | --- |
-| ![Context Menu Before](./screenshots/before.png) | ![Context Menu After](./screenshots/after.png) |
+| ![Context Menu Before](https://raw.githubusercontent.com/EpicStuff/vscode-custom-context-menu/main/screenshots/before.png) | ![Context Menu After](https://raw.githubusercontent.com/EpicStuff/vscode-custom-context-menu/main/screenshots/after.png) |
 
 ## Usage
 


### PR DESCRIPTION
### Motivation
- Images in the README were referenced with relative paths which may not render correctly in VS Code/marketplace contexts. 
- Use raw GitHub URLs so the logo and screenshots display when the README is rendered outside the repository.

### Description
- Updated `README.md` to replace relative image links with raw GitHub URLs (e.g., `https://raw.githubusercontent.com/EpicStuff/vscode-custom-context-menu/main/...`) for `images/logo.png` and `screenshots/before.png`/`screenshots/after.png`.
- This is a documentation-only change and does not modify any code, configuration, or package metadata.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fe091f3a48328b2af6ea6379ede69)