### PR TITLE
Avoid repositioning non-context menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "custom-context-menu",
 	"displayName": "Custom Context Menu",
 	"description": "Custom Context Menu Cleaner for Visual Studio Code",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"publisher": "EpicStuff",
 	"engines": {
 		"vscode": "^1.92.0"

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -38,10 +38,12 @@
 
   // get mouse position
   let mouse_y = 0;
+  let last_mouse_time = 0;
   document.addEventListener("mouseup", (e) => {
     // bug: not working in titlebar
     if (e.button === 2) {
       mouse_y = e.clientY;
+      last_mouse_time = Date.now();
     }
   });
 
@@ -73,6 +75,10 @@
 
     // fix context menu position
     if (menu.matches(".monaco-submenu")) {
+      return;
+    }
+    const is_recent_right_click = Date.now() - last_mouse_time < 1000;
+    if (!is_recent_right_click) {
       return;
     }
     let menu_top = parseInt(menu.style.top);


### PR DESCRIPTION
### Motivation
- Clicking the settings icon opened a menu that was being repositioned by the context-menu script even when it wasn't triggered by a right-click. 
- The intent is to keep context menus aligned to the cursor while not affecting other menus like the settings menu.

### Description
- Added a `last_mouse_time` timestamp and updated the `mouseup` handler to record the time on right-clicks (`button === 2`).
- Added a recent-right-click check (`is_recent_right_click = Date.now() - last_mouse_time < 1000`) and early-return to skip repositioning when no recent right-click was detected.
- Changes are implemented in `src/static/user.js` and preserve existing skips for titlebar containers and submenus.

### Testing
- No automated tests were run for this change.
- Code change was committed and the modified file is `src/static/user.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960055dff248328ac63f6bb133e95ed)