### PR TITLE
Add pkexec fallback for Linux installs

### DIFF
--- a/src/messages.js
+++ b/src/messages.js
@@ -1,5 +1,6 @@
 exports.messages = {
-	admin: "Run VS Code with admin privileges so the changes can be applied.",
+	admin:
+		"Enter your admin password in the prompt so the changes can be applied.",
 	enabled:
 		"Custom Context Menu enabled. Restart to take effect. " +
 		"If Code complains about it is corrupted, CLICK DON'T SHOW AGAIN. ",


### PR DESCRIPTION
### Motivation
- Support VS Code installations owned by root on Linux by providing an elevated fallback when file operations fail due to permissions. 
- Trigger a system password prompt so users can approve elevated operations instead of manually running the editor as root. 

### Description
- Add `os`, `child_process.execFile` and a promisified `execFileAsync` and implement `runElevatedCommand` which invokes `pkexec` to perform privileged `cp`/`rm` operations on Linux. 
- Provide fallback helpers `writeFileWithFallback`, `writeFileWithElevated`, `copyFileWithFallback`, and `deleteFileWithFallback` that attempt normal `fs.promises` operations and fall back to elevated `pkexec` flows on `EACCES`/`EPERM`. 
- Wire the elevated fallbacks into the install/uninstall and backup/restore flows by updating `createBackup`, `restoreBackup`, `deleteBackupFiles`, and `performPatch` to use the new helpers. 
- Update the admin message in `src/messages.js` to instruct users to approve the password prompt. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a6b4f63d88328b4bcafbbee340a80)