### PR TITLE
Recognize `.action-label.separator` as separator target and adjust visibility logic

### DIFF
--- a/src/static/user.js
+++ b/src/static/user.js
@@ -142,7 +142,12 @@
       const itemStyle = getComputedStyle(item);
       const targetStyle = getComputedStyle(target);
       const hasRects =
-        target.getClientRects().length > 0 || item.getClientRects().length > 0;
+        target.getClientRects().length > 0 ||
+        item.getClientRects().length > 0 ||
+        target.offsetWidth > 0 ||
+        target.offsetHeight > 0 ||
+        item.offsetWidth > 0 ||
+        item.offsetHeight > 0;
       return (
         itemStyle.display !== "none" &&
         itemStyle.visibility !== "hidden" &&

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -122,9 +122,23 @@
 
   function hideTrailingSeparator(container) {
     const items = Array.from(container.querySelectorAll(".action-item"));
-    const isRendered = item => {
+    const getSeparatorElement = item => {
+      const separator = item.querySelector(".action-label.separator");
+      if (separator && separator.closest(".action-item") === item) {
+        return separator;
+      }
+      return null;
+    };
+    const getVisibilityTarget = item => {
+      const separator = getSeparatorElement(item);
+      if (separator) {
+        return separator;
+      }
       const label = item.querySelector(".action-label, .action-menu-item");
-      const target = label || item;
+      return label || item;
+    };
+    const isRendered = item => {
+      const target = getVisibilityTarget(item);
       const itemStyle = getComputedStyle(item);
       const targetStyle = getComputedStyle(target);
       return (
@@ -136,6 +150,7 @@
       );
     };
     const isSeparator = item =>
+      getSeparatorElement(item) ||
       item.classList.contains("separator") ||
       item.getAttribute("role") === "separator" ||
       item.querySelector(".codicon.separator");

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -137,6 +137,11 @@
       const label = item.querySelector(".action-label, .action-menu-item");
       return label || item;
     };
+    const isSeparator = item =>
+      getSeparatorElement(item) ||
+      item.classList.contains("separator") ||
+      item.getAttribute("role") === "separator" ||
+      item.querySelector(".codicon.separator");
     const isRendered = item => {
       const target = getVisibilityTarget(item);
       const itemStyle = getComputedStyle(item);
@@ -148,19 +153,18 @@
         target.offsetHeight > 0 ||
         item.offsetWidth > 0 ||
         item.offsetHeight > 0;
+      const hasSeparatorBorder =
+        isSeparator(item) &&
+        (parseFloat(targetStyle.borderTopWidth) > 0 ||
+          parseFloat(targetStyle.borderBottomWidth) > 0);
       return (
         itemStyle.display !== "none" &&
         itemStyle.visibility !== "hidden" &&
         targetStyle.display !== "none" &&
         targetStyle.visibility !== "hidden" &&
-        hasRects
+        (hasRects || hasSeparatorBorder)
       );
     };
-    const isSeparator = item =>
-      getSeparatorElement(item) ||
-      item.classList.contains("separator") ||
-      item.getAttribute("role") === "separator" ||
-      item.querySelector(".codicon.separator");
     for (const item of items) {
       if (item.dataset.autoHideSeparator === "true") {
         item.style.removeProperty("display");

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -123,7 +123,7 @@
   function hideTrailingSeparator(container) {
     const items = Array.from(container.querySelectorAll(".action-item"));
     const getSeparatorElement = item => {
-      const separator = item.querySelector(".action-label.separator");
+      const separator = item.querySelector(":scope > .action-label.separator");
       if (separator && separator.closest(".action-item") === item) {
         return separator;
       }
@@ -141,12 +141,14 @@
       const target = getVisibilityTarget(item);
       const itemStyle = getComputedStyle(item);
       const targetStyle = getComputedStyle(target);
+      const hasRects =
+        target.getClientRects().length > 0 || item.getClientRects().length > 0;
       return (
         itemStyle.display !== "none" &&
         itemStyle.visibility !== "hidden" &&
         targetStyle.display !== "none" &&
         targetStyle.visibility !== "hidden" &&
-        target.getClientRects().length > 0
+        hasRects
       );
     };
     const isSeparator = item =>

--- a/src/static/user.js
+++ b/src/static/user.js
@@ -72,6 +72,22 @@
     requestAnimationFrame(() => {
       hideTrailingSeparator(container);
     });
+    if (!container.__customContextMenuObserver) {
+      const separatorObserver = new MutationObserver(() => {
+        if (container.__customContextMenuRaf) {
+          return;
+        }
+        container.__customContextMenuRaf = requestAnimationFrame(() => {
+          container.__customContextMenuRaf = null;
+          hideTrailingSeparator(container);
+        });
+      });
+      separatorObserver.observe(container, {
+        childList: true,
+        subtree: true,
+      });
+      container.__customContextMenuObserver = separatorObserver;
+    }
 
     // fix context menu position
     if (menu.matches(".monaco-submenu")) {


### PR DESCRIPTION
### Motivation
- Context menu separators can be rendered as an `.action-label.separator` element inside `li.action-item`, and the previous detection missed this DOM shape. 
- Treating the label node as the separator and visibility target ensures leading/trailing separator items are correctly hidden. 

### Description
- Updated `src/static/user.js` to add `getSeparatorElement(item)` which returns the `.action-label.separator` only when it belongs to the same `.action-item` parent. 
- Added `getVisibilityTarget(item)` to prefer the separator label as the element used for visibility checks, falling back to `.action-label`, `.action-menu-item`, or the item itself. 
- Reworked `isRendered` to compute styles and client rects against the `getVisibilityTarget` element. 
- Updated `isSeparator` to consider `getSeparatorElement(item)` in addition to the previous checks, and preserved the behavior of hiding the parent `.action-item` when the first/last visible node is a separator. 

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b87375a88328867ab57ee239cee1)