### PR TITLE
Detect descendant separators in context menu items

### DIFF
--- a/src/static/user.js
+++ b/src/static/user.js
@@ -138,7 +138,8 @@
 		const isSeparator = item =>
 			item.classList.contains("separator") ||
 			item.getAttribute("role") === "separator" ||
-			item.querySelector(".codicon.separator");
+			item.querySelector(".codicon.separator") ||
+			item.querySelector(".action-label.separator, .separator");
 		for (const item of items) {
 			if (item.dataset.autoHideSeparator === "true") {
 				item.style.removeProperty("display");


### PR DESCRIPTION
### Motivation
- Ensure separator items are detected even when the separator markup is on a descendant (for example `.action-label.separator` or `.separator`) so leading/trailing separators are correctly hidden.

### Description
- Updated `hideTrailingSeparator` in `src/static/user.js` to extend the `isSeparator` check with `item.querySelector(".action-label.separator, .separator")`, keeping the existing first/last visible separator hiding behavior.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c1fff91883288cd87b8cbb34d08e)